### PR TITLE
FIX: Initial Commit of Bug Fixing

### DIFF
--- a/src/collector/process.rs
+++ b/src/collector/process.rs
@@ -1,12 +1,65 @@
 use anyhow::Result;
 use std::path::PathBuf;
-use sysinfo::{System};
+use sysinfo::System;
 
 #[derive(Debug, Clone)]
 pub struct ProcSnapshot {
     pub pid: u32,
     pub name: String,
     pub exe_path: Option<PathBuf>,
+}
+
+// Jadi gini Ko, kita pakai ExecutablePath() dari windows API
+// Habis itu kita pakai sysinfo::Process::exe() sebagai fallback
+// Kenapa? Karena sysinfo::Process::exe() itu kadang error
+// Terus kita pakai PROCESS_QUERY_LIMITED_INFORMATION (0x1000)
+// Supaya bisa baca process SYSTEM
+#[cfg(target_os = "windows")]
+fn query_exe_path_win(pid: u32) -> Option<PathBuf> {
+    use std::ffi::OsString;
+    use std::os::windows::ffi::OsStringExt;
+
+    // Constants
+    const PROCESS_QUERY_LIMITED_INFORMATION: u32 = 0x1000;
+
+    // FFI declarations (kernel32)
+    #[link(name = "kernel32")]
+    extern "system" {
+        fn OpenProcess(access: u32, inherit: i32, pid: u32) -> *mut std::ffi::c_void;
+        fn CloseHandle(handle: *mut std::ffi::c_void) -> i32;
+        fn QueryFullProcessImageNameW(
+            process: *mut std::ffi::c_void,
+            flags: u32,
+            buffer: *mut u16,
+            size: *mut u32,
+        ) -> i32;
+    }
+
+    unsafe {
+        let handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid);
+        if handle.is_null() {
+            return None;
+        }
+
+        let mut buf = [0u16; 1024];
+        let mut len = buf.len() as u32;
+
+        let ok = QueryFullProcessImageNameW(handle, 0, buf.as_mut_ptr(), &mut len);
+        CloseHandle(handle);
+
+        if ok == 0 || len == 0 {
+            return None;
+        }
+
+        let path = OsString::from_wide(&buf[..len as usize]);
+        Some(PathBuf::from(path))
+    }
+}
+
+/// Non-Windows stub
+#[cfg(not(target_os = "windows"))]
+fn query_exe_path_win(_pid: u32) -> Option<PathBuf> {
+    None
 }
 
 pub fn collect_process_snapshot() -> Result<Vec<ProcSnapshot>> {
@@ -18,9 +71,19 @@ pub fn collect_process_snapshot() -> Result<Vec<ProcSnapshot>> {
     for (pid, proc_) in sys.processes() {
         let pid_u32 = pid.to_string().parse::<u32>().unwrap_or(0);
         let name = proc_.name().to_string();
-        let exe_path: Option<PathBuf> = proc_.exe().map(|p| p.to_path_buf());
 
-        out.push(ProcSnapshot { pid: pid_u32, name, exe_path });
+        // Primary source dari sysinfo.  Falls back to the Windows API jika:
+        // crate cannot read the path (e.g. for SYSTEM / other-user processes).
+        let exe_path: Option<PathBuf> = proc_
+            .exe()
+            .map(|p| p.to_path_buf())
+            .or_else(|| query_exe_path_win(pid_u32));
+
+        out.push(ProcSnapshot {
+            pid: pid_u32,
+            name,
+            exe_path,
+        });
     }
 
     Ok(out)


### PR DESCRIPTION
Dear Steven Jonathan,

I outline the methodology I implemented to address systemic limitations in process path retrieval within the edr-lite framework. My primary objective was to overcome privilege-related failures frequently encountered during high-level API calls when interacting with protected system processes.

I developed a robust fallback mechanism within src/collector/process.rs by leveraging the native Windows API. When the sysinfo crate fails to retrieve an executable path, I programmed the system to extract the process ID and attempt manual access through the OpenProcess function.

A critical component of my solution involves requesting PROCESS_QUERY_LIMITED_INFORMATION (0x1000) access privileges. I utilized this specific, lower-level set of rights because Windows typically grants them to standard users for nearly every process, including those owned by the SYSTEM account.

I mapped the QueryFullProcessImageNameW function to safely read the executable's image path once limited information rights are granted. This approach ensures that the path is resolved correctly, while still providing a graceful fallback if the operation fails.

To maintain the architectural validity of the codebase, I integrated cross-platform stubs using #[cfg(not(target_os = "windows"))]. This ensures that my implementation remains functional across different operating systems by gracefully returning None if the code is ever ported to a non-Windows environment.

By implementing this native Windows API fallback, I have addressed the critical limitation of process path retrieval in protected environments. This approach balances high-level crate abstraction with low-level system calls, ensuring that edr-lite remains both performant and reliable across various privilege levels.

Sincerely,
Ivan :)