### PR TITLE
Fixing Vuln around the Renamed LOLBin

### DIFF
--- a/src/collector/mod.rs
+++ b/src/collector/mod.rs
@@ -1,1 +1,2 @@
+pub mod pe_info;
 pub mod process;

--- a/src/collector/pe_info.rs
+++ b/src/collector/pe_info.rs
@@ -1,28 +1,28 @@
 use std::path::Path;
 
-/// Metadata extracted from a PE file's version-information resource.
+// Metadata extracted from a PE file's version information resources.
 #[derive(Debug, Clone, Default)]
 pub struct PeMetadata {
-    /// The `OriginalFilename` field from the VS_VERSION_INFO resource.
-    /// This is baked into the binary at compile time and survives renaming.
+    // The `OriginalFilename` field from the VS_VERSION_INFO resource.
+    // This is baked into the binary at compile time and survives renaming.
     pub original_filename: Option<String>,
 }
 
-/// Read PE version-info from an executable on disk.
-///
-/// On Windows we call `GetFileVersionInfoW` / `VerQueryValueW` through FFI.
-/// On non-Windows platforms this is a no-op stub that always returns `None`.
+// Read PE version-info from an executable on disk.
+
+/// Di Windows kita pakai `GetFileVersionInfoW` / `VerQueryValueW` melalui FFI.
+/// Kalau di non-Windows platforms ini cuma no-op stub yang selalu return `None`.
 pub fn read_pe_metadata<P: AsRef<Path>>(path: P) -> Option<PeMetadata> {
     _read_pe_metadata_impl(path.as_ref())
 }
 
-// ── Windows implementation ─────────────────────────────────────────────────
+// Windows implementation
 #[cfg(target_os = "windows")]
 fn _read_pe_metadata_impl(path: &Path) -> Option<PeMetadata> {
     use std::ffi::OsStr;
     use std::os::windows::ffi::OsStrExt;
 
-    // --- FFI declarations (version.dll) ---
+    // FFI declarations (version.dll)
     #[link(name = "version")]
     extern "system" {
         fn GetFileVersionInfoSizeW(
@@ -62,7 +62,7 @@ fn _read_pe_metadata_impl(path: &Path) -> Option<PeMetadata> {
         String::from_utf16_lossy(&slice[..end])
     }
 
-    // 1. Get the size of the version-info block
+    // Get the size of the version-info block
     let file_wide = to_wide(&path.to_string_lossy());
     let mut handle: u32 = 0;
     let size = unsafe { GetFileVersionInfoSizeW(file_wide.as_ptr(), &mut handle) };
@@ -70,7 +70,7 @@ fn _read_pe_metadata_impl(path: &Path) -> Option<PeMetadata> {
         return None;
     }
 
-    // 2. Retrieve the version-info block
+    // Retrieve the version-info block
     let mut data = vec![0u8; size as usize];
     let ok = unsafe {
         GetFileVersionInfoW(file_wide.as_ptr(), handle, size, data.as_mut_ptr())
@@ -79,7 +79,7 @@ fn _read_pe_metadata_impl(path: &Path) -> Option<PeMetadata> {
         return None;
     }
 
-    // 3. Query the translation array to learn the code page/language pair
+    // Query the translation array to learn the code page/language pair
     let translation_key = to_wide("\\VarFileInfo\\Translation");
     let mut trans_ptr: *const u8 = std::ptr::null();
     let mut trans_len: u32 = 0;
@@ -102,7 +102,7 @@ fn _read_pe_metadata_impl(path: &Path) -> Option<PeMetadata> {
         (words[0], words[1])
     };
 
-    // 4. Build the sub-block path for OriginalFilename
+    // Build the sub-block path for OriginalFilename
     let sub_block = format!(
         "\\StringFileInfo\\{:04x}{:04x}\\OriginalFilename",
         lang_id, code_page
@@ -130,7 +130,7 @@ fn _read_pe_metadata_impl(path: &Path) -> Option<PeMetadata> {
     Some(PeMetadata { original_filename })
 }
 
-// ── Non-Windows stub ───────────────────────────────────────────────────────
+// Non-Windows stub
 #[cfg(not(target_os = "windows"))]
 fn _read_pe_metadata_impl(_path: &Path) -> Option<PeMetadata> {
     None

--- a/src/collector/pe_info.rs
+++ b/src/collector/pe_info.rs
@@ -1,0 +1,137 @@
+use std::path::Path;
+
+/// Metadata extracted from a PE file's version-information resource.
+#[derive(Debug, Clone, Default)]
+pub struct PeMetadata {
+    /// The `OriginalFilename` field from the VS_VERSION_INFO resource.
+    /// This is baked into the binary at compile time and survives renaming.
+    pub original_filename: Option<String>,
+}
+
+/// Read PE version-info from an executable on disk.
+///
+/// On Windows we call `GetFileVersionInfoW` / `VerQueryValueW` through FFI.
+/// On non-Windows platforms this is a no-op stub that always returns `None`.
+pub fn read_pe_metadata<P: AsRef<Path>>(path: P) -> Option<PeMetadata> {
+    _read_pe_metadata_impl(path.as_ref())
+}
+
+// ── Windows implementation ─────────────────────────────────────────────────
+#[cfg(target_os = "windows")]
+fn _read_pe_metadata_impl(path: &Path) -> Option<PeMetadata> {
+    use std::ffi::OsStr;
+    use std::os::windows::ffi::OsStrExt;
+
+    // --- FFI declarations (version.dll) ---
+    #[link(name = "version")]
+    extern "system" {
+        fn GetFileVersionInfoSizeW(
+            lptstr_filename: *const u16,
+            lpdw_handle: *mut u32,
+        ) -> u32;
+
+        fn GetFileVersionInfoW(
+            lptstr_filename: *const u16,
+            dw_handle: u32,
+            dw_len: u32,
+            lp_data: *mut u8,
+        ) -> i32;
+
+        fn VerQueryValueW(
+            p_block: *const u8,
+            lp_sub_block: *const u16,
+            lp_buffer: *mut *const u8,
+            pu_len: *mut u32,
+        ) -> i32;
+    }
+
+    /// Encode a Rust string as a null-terminated wide (UTF-16) string.
+    fn to_wide(s: &str) -> Vec<u16> {
+        OsStr::new(s).encode_wide().chain(std::iter::once(0)).collect()
+    }
+
+    /// Safely read a null-terminated UTF-16 string from a raw pointer.
+    unsafe fn wide_ptr_to_string(ptr: *const u8, byte_len: u32) -> String {
+        if ptr.is_null() || byte_len == 0 {
+            return String::new();
+        }
+        // byte_len is in *characters* (WCHARs) for string queries
+        let slice = std::slice::from_raw_parts(ptr as *const u16, byte_len as usize);
+        // Strip trailing NUL
+        let end = slice.iter().position(|&c| c == 0).unwrap_or(slice.len());
+        String::from_utf16_lossy(&slice[..end])
+    }
+
+    // 1. Get the size of the version-info block
+    let file_wide = to_wide(&path.to_string_lossy());
+    let mut handle: u32 = 0;
+    let size = unsafe { GetFileVersionInfoSizeW(file_wide.as_ptr(), &mut handle) };
+    if size == 0 {
+        return None;
+    }
+
+    // 2. Retrieve the version-info block
+    let mut data = vec![0u8; size as usize];
+    let ok = unsafe {
+        GetFileVersionInfoW(file_wide.as_ptr(), handle, size, data.as_mut_ptr())
+    };
+    if ok == 0 {
+        return None;
+    }
+
+    // 3. Query the translation array to learn the code page/language pair
+    let translation_key = to_wide("\\VarFileInfo\\Translation");
+    let mut trans_ptr: *const u8 = std::ptr::null();
+    let mut trans_len: u32 = 0;
+    let ok = unsafe {
+        VerQueryValueW(
+            data.as_ptr(),
+            translation_key.as_ptr(),
+            &mut trans_ptr,
+            &mut trans_len,
+        )
+    };
+
+    // Each translation entry is 4 bytes: u16 lang_id + u16 code_page
+    if ok == 0 || trans_len < 4 || trans_ptr.is_null() {
+        return None;
+    }
+
+    let (lang_id, code_page) = unsafe {
+        let words = std::slice::from_raw_parts(trans_ptr as *const u16, 2);
+        (words[0], words[1])
+    };
+
+    // 4. Build the sub-block path for OriginalFilename
+    let sub_block = format!(
+        "\\StringFileInfo\\{:04x}{:04x}\\OriginalFilename",
+        lang_id, code_page
+    );
+    let sub_wide = to_wide(&sub_block);
+
+    let mut val_ptr: *const u8 = std::ptr::null();
+    let mut val_len: u32 = 0;
+    let ok = unsafe {
+        VerQueryValueW(
+            data.as_ptr(),
+            sub_wide.as_ptr(),
+            &mut val_ptr,
+            &mut val_len,
+        )
+    };
+
+    let original_filename = if ok != 0 && !val_ptr.is_null() && val_len > 0 {
+        let s = unsafe { wide_ptr_to_string(val_ptr, val_len) };
+        if s.is_empty() { None } else { Some(s) }
+    } else {
+        None
+    };
+
+    Some(PeMetadata { original_filename })
+}
+
+// ── Non-Windows stub ───────────────────────────────────────────────────────
+#[cfg(not(target_os = "windows"))]
+fn _read_pe_metadata_impl(_path: &Path) -> Option<PeMetadata> {
+    None
+}

--- a/src/collector/process.rs
+++ b/src/collector/process.rs
@@ -3,6 +3,8 @@ use std::path::PathBuf;
 use sysinfo::System;
 use std::process::Command;
 
+use super::pe_info;
+
 pub fn is_elevated() -> bool {
     #[cfg(target_os = "windows")]
     {
@@ -22,6 +24,9 @@ pub struct ProcSnapshot {
     pub name: String,
     pub exe_path: Option<PathBuf>,
     pub is_elevated_process: bool,
+    // The OriginalFilename field from the PE VersionInfo resource.
+    // Survives file renames — used to detect renamed LOLBins.
+    pub original_filename: Option<String>,
 }
 
 // Jadi gini Ko, kita pakai ExecutablePath() dari windows API
@@ -94,11 +99,19 @@ pub fn collect_process_snapshot() -> Result<Vec<ProcSnapshot>> {
             .map(|p| p.to_path_buf())
             .or_else(|| query_exe_path_win(pid_u32));
 
+        // Extract OriginalFilename from PE VersionInfo resource.
+        // This survives file renames and is the key to detecting renamed LOLBins.
+        let original_filename = exe_path
+            .as_ref()
+            .and_then(|p| pe_info::read_pe_metadata(p))
+            .and_then(|m| m.original_filename);
+
         out.push(ProcSnapshot {
             pid: pid_u32,
             name,
             exe_path,
             is_elevated_process: false,
+            original_filename,
         });
     }
 

--- a/src/detector/rules.rs
+++ b/src/detector/rules.rs
@@ -46,17 +46,54 @@ impl RuleEngine {
         LOLBINS.iter().any(|x| *x == name)
     }
 
+    // Normalize a PE OriginalFilename for comparison.
+    // Windows PE VersionInfo sering pakai suffix .MUI atau .dll untuk binary
+    // yang sebenarnya exe, jadi kita harus normalize dulu sebelum compare.
+    //   "PowerShell.EXE.MUI" → "powershell.exe"
+    //   "CTFMON.EXE.MUI"     → "ctfmon.exe"
+    //   "Copilot.dll"        → "copilot.dll" (tetap, bukan rename sebenarnya)
+    //   "svchost.exe.mui"    → "svchost.exe"
+    fn normalize_original_filename(orig: &str) -> String {
+        let s = orig.trim().to_lowercase();
+        // Strip trailing .mui (resource-only naming convention)
+        if let Some(base) = s.strip_suffix(".mui") {
+            base.to_string()
+        } else {
+            s
+        }
+    }
+
     // Determine whether a binary has been renamed by comparing its current
     // file-system name to the OriginalFilename from its PE VersionInfo.
     // Returns `true` when the two names are present AND different (case-insensitive).
+    //
+    // Handles common Windows PE conventions:
+    //  - .MUI suffix (e.g. "PowerShell.EXE.MUI" is NOT a rename of powershell.exe)
+    //  - .dll vs .exe mismatch in Electron/MSIX apps (e.g. "Copilot.dll" is NOT
+    //    a rename of Copilot.exe — same stem = not suspicious)
     fn is_renamed(actual_name: &str, original_filename: Option<&str>) -> bool {
         match original_filename {
             Some(orig) => {
-                let orig_trimmed = orig.trim().to_lowercase();
-                if orig_trimmed.is_empty() {
+                let normalized = Self::normalize_original_filename(orig);
+                if normalized.is_empty() {
                     return false;
                 }
-                orig_trimmed != actual_name.to_lowercase()
+                let actual_lc = actual_name.to_lowercase();
+
+                // Exact match after normalization artinya not renamed
+                if normalized == actual_lc {
+                    return false;
+                }
+
+                // Same stem, different extension (.exe vs .dll) -> not renamed
+                // Ini sering terjadi di Electron/MSIX apps
+                let stem_actual = actual_lc.rsplit_once('.').map(|(s, _)| s).unwrap_or(&actual_lc);
+                let stem_orig = normalized.rsplit_once('.').map(|(s, _)| s).unwrap_or(&normalized);
+                if stem_actual == stem_orig {
+                    return false;
+                }
+
+                true
             }
             None => false,
         }
@@ -75,7 +112,12 @@ impl RuleEngine {
         if path_lc.contains("\\downloads\\") {
             flags.push("exec_from_downloads".to_string());
         }
-        if path_lc.contains("\\appdata\\roaming\\") || path_lc.contains("\\appdata\\local\\") {
+        // AppData\Local\Programs\ itu standard install directory untuk user-level
+        // apps (Discord, VS Code, Opera, dsb). Jangan flag ini sebagai suspicious.
+        // Yang kita flag hanya direct execution dari AppData yang bukan Programs.
+        let is_appdata = path_lc.contains("\\appdata\\roaming\\") || path_lc.contains("\\appdata\\local\\");
+        let is_programs = path_lc.contains("\\appdata\\local\\programs\\");
+        if is_appdata && !is_programs {
             flags.push("exec_from_appdata".to_string());
         }
         flags
@@ -104,16 +146,17 @@ impl RuleEngine {
         }
 
         // LOLBin detection: by actual name OR by OriginalFilename
-        let orig_lc = original_filename.map(|s| s.trim().to_lowercase());
+        // Pakai normalize supaya .MUI suffix di-strip sebelum compare
+        let orig_normalized = original_filename.map(|s| Self::normalize_original_filename(s));
         let is_lolbin_by_name = Self::is_lolbin(&name_lc);
-        let is_lolbin_by_orig = orig_lc.as_deref().map_or(false, Self::is_lolbin);
+        let is_lolbin_by_orig = orig_normalized.as_deref().map_or(false, Self::is_lolbin);
 
         if is_lolbin_by_name || is_lolbin_by_orig {
             flags.push("lolbin_process".to_string());
         }
 
         // Renamed binary detection
-        if Self::is_renamed(&name_lc, orig_lc.as_deref()) {
+        if Self::is_renamed(&name_lc, orig_normalized.as_deref()) {
             flags.push("renamed_binary".to_string());
         }
 
@@ -136,7 +179,8 @@ impl RuleEngine {
 
         let name_lc = proc_name.to_lowercase();
         let path_lc = exe_path.unwrap_or("").to_lowercase();
-        let orig_lc = original_filename.map(|s| s.trim().to_lowercase());
+        // Pakai normalize supaya .MUI suffix di-strip sebelum compare
+        let orig_normalized = original_filename.map(|s| Self::normalize_original_filename(s));
 
         // Kalau ketemu missing exe_path
         let known_system = ["lsass.exe", "csrss.exe", "smss.exe", "wininit.exe"];
@@ -147,7 +191,7 @@ impl RuleEngine {
         // Allowlist short-circuit
         // Only trust the allowlist when the binary has NOT been renamed.
         // A renamed binary is suspicious regardless of its current name.
-        let renamed = Self::is_renamed(&name_lc, orig_lc.as_deref());
+        let renamed = Self::is_renamed(&name_lc, orig_normalized.as_deref());
         if self.allowlisted_names.contains(&name_lc) && !renamed {
             return DetectionResult {
                 flags: vec!["allowlisted_name".to_string()],
@@ -168,7 +212,7 @@ impl RuleEngine {
 
         // LOLBin detection: by actual name OR by OriginalFilename
         let is_lolbin_by_name = Self::is_lolbin(&name_lc);
-        let is_lolbin_by_orig = orig_lc.as_deref().map_or(false, Self::is_lolbin);
+        let is_lolbin_by_orig = orig_normalized.as_deref().map_or(false, Self::is_lolbin);
 
         if is_lolbin_by_name || is_lolbin_by_orig {
             flags.push("lolbin_process".to_string());

--- a/src/detector/rules.rs
+++ b/src/detector/rules.rs
@@ -1,6 +1,22 @@
 use crate::models::{DetectionResult, Severity};
 use std::{collections::HashSet, fs, path::Path};
 
+// Well-known Living-off-the-Land Binaries.
+// Checked against BOTH the actual process name AND the PE OriginalFilename.
+const LOLBINS: &[&str] = &[
+    "powershell.exe",
+    "pwsh.exe",
+    "cmd.exe",
+    "wscript.exe",
+    "cscript.exe",
+    "mshta.exe",
+    "rundll32.exe",
+    "regsvr32.exe",
+    "certutil.exe",
+    "bitsadmin.exe",
+    "wmic.exe",
+];
+
 #[derive(Debug, Clone)]
 pub struct RuleEngine {
     allowlisted_names: HashSet<String>,
@@ -23,18 +39,116 @@ impl RuleEngine {
         }
     }
 
-    pub fn detect(&self, proc_name: &str, exe_path: Option<&str>, sha256: Option<&str>) -> DetectionResult {
+    // Helper Function Call --> Intinya jadi helper function ko
+
+    // Check if a name is in the LOLBin list.
+    fn is_lolbin(name: &str) -> bool {
+        LOLBINS.iter().any(|x| *x == name)
+    }
+
+    // Determine whether a binary has been renamed by comparing its current
+    // file-system name to the OriginalFilename from its PE VersionInfo.
+    // Returns `true` when the two names are present AND different (case-insensitive).
+    fn is_renamed(actual_name: &str, original_filename: Option<&str>) -> bool {
+        match original_filename {
+            Some(orig) => {
+                let orig_trimmed = orig.trim().to_lowercase();
+                if orig_trimmed.is_empty() {
+                    return false;
+                }
+                orig_trimmed != actual_name.to_lowercase()
+            }
+            None => false,
+        }
+    }
+
+    // Path-based flags
+
+    fn path_flags(path_lc: &str) -> Vec<String> {
+        let mut flags = Vec::new();
+        if path_lc.is_empty() {
+            return flags;
+        }
+        if path_lc.contains("\\appdata\\local\\temp\\") || path_lc.contains("\\windows\\temp\\") {
+            flags.push("exec_from_temp".to_string());
+        }
+        if path_lc.contains("\\downloads\\") {
+            flags.push("exec_from_downloads".to_string());
+        }
+        if path_lc.contains("\\appdata\\roaming\\") || path_lc.contains("\\appdata\\local\\") {
+            flags.push("exec_from_appdata".to_string());
+        }
+        flags
+    }
+
+    // public API used by main.rs
+
+    // Lightweight pre-scan: returns a list of flag strings so `main.rs` can
+    // decide whether it is worth computing the SHA-256 hash for this process.
+    pub fn quick_flags(
+        &self,
+        proc_name: &str,
+        exe_path: Option<&str>,
+        original_filename: Option<&str>,
+    ) -> Vec<String> {
         let mut flags: Vec<String> = Vec::new();
 
         let name_lc = proc_name.to_lowercase();
         let path_lc = exe_path.unwrap_or("").to_lowercase();
 
+        // Path-based flags
+        if path_lc.is_empty() {
+            flags.push("no_exe_path".to_string());
+        } else {
+            flags.extend(Self::path_flags(&path_lc));
+        }
+
+        // LOLBin detection: by actual name OR by OriginalFilename
+        let orig_lc = original_filename.map(|s| s.trim().to_lowercase());
+        let is_lolbin_by_name = Self::is_lolbin(&name_lc);
+        let is_lolbin_by_orig = orig_lc.as_deref().map_or(false, Self::is_lolbin);
+
+        if is_lolbin_by_name || is_lolbin_by_orig {
+            flags.push("lolbin_process".to_string());
+        }
+
+        // Renamed binary detection
+        if Self::is_renamed(&name_lc, orig_lc.as_deref()) {
+            flags.push("renamed_binary".to_string());
+        }
+
+        if self.allowlisted_names.contains(&name_lc) {
+            flags.push("allowlisted_name".to_string());
+        }
+
+        flags
+    }
+
+    // Full detection with severity classification.
+    pub fn detect(
+        &self,
+        proc_name: &str,
+        exe_path: Option<&str>,
+        original_filename: Option<&str>,
+        sha256: Option<&str>,
+    ) -> DetectionResult {
+        let mut flags: Vec<String> = Vec::new();
+
+        let name_lc = proc_name.to_lowercase();
+        let path_lc = exe_path.unwrap_or("").to_lowercase();
+        let orig_lc = original_filename.map(|s| s.trim().to_lowercase());
+
+        // Kalau ketemu missing exe_path
         let known_system = ["lsass.exe", "csrss.exe", "smss.exe", "wininit.exe"];
         if exe_path.is_none() && !known_system.contains(&name_lc.as_str()) {
             flags.push("no_exe_path".to_string());
         }
 
-        if self.allowlisted_names.contains(&name_lc) {
+        // Allowlist short-circuit
+        // Only trust the allowlist when the binary has NOT been renamed.
+        // A renamed binary is suspicious regardless of its current name.
+        let renamed = Self::is_renamed(&name_lc, orig_lc.as_deref());
+        if self.allowlisted_names.contains(&name_lc) && !renamed {
             return DetectionResult {
                 flags: vec!["allowlisted_name".to_string()],
                 severity: Severity::Low,
@@ -49,38 +163,48 @@ impl RuleEngine {
             flags.push("no_hash".to_string());
         }
 
-        if !path_lc.is_empty() {
-            if path_lc.contains("\\appdata\\local\\temp\\") || path_lc.contains("\\windows\\temp\\") {
-                flags.push("exec_from_temp".to_string());
-            }
-            if path_lc.contains("\\downloads\\") {
-                flags.push("exec_from_downloads".to_string());
-            }
-            if path_lc.contains("\\appdata\\roaming\\") || path_lc.contains("\\appdata\\local\\") {
-                flags.push("exec_from_appdata".to_string());
-            }
-        }
+        // path-based flags
+        flags.extend(Self::path_flags(&path_lc));
 
-        let lolbins = [
-            "powershell.exe",
-            "pwsh.exe",
-            "cmd.exe",
-            "wscript.exe",
-            "cscript.exe",
-            "mshta.exe",
-            "rundll32.exe",
-            "regsvr32.exe",
-            "certutil.exe",
-            "bitsadmin.exe",
-            "wmic.exe",
-        ];
-        if lolbins.iter().any(|x| *x == name_lc) {
+        // LOLBin detection: by actual name OR by OriginalFilename
+        let is_lolbin_by_name = Self::is_lolbin(&name_lc);
+        let is_lolbin_by_orig = orig_lc.as_deref().map_or(false, Self::is_lolbin);
+
+        if is_lolbin_by_name || is_lolbin_by_orig {
             flags.push("lolbin_process".to_string());
         }
 
-        let severity = if flags.contains(&"exec_from_temp".to_string()) && flags.contains(&"lolbin_process".to_string()) {
+        // renamed binary detection
+        if renamed {
+            flags.push("renamed_binary".to_string());
+        }
+
+        // If a LOLBin was detected only through the OriginalFilename
+        // (meaning the file was renamed to evade name-based detection),
+        // flag the masquerade explicitly.
+        if !is_lolbin_by_name && is_lolbin_by_orig && renamed {
+            flags.push("lolbin_masquerade".to_string());
+        }
+
+        // severity classification
+        let has_exec_from = flags.iter().any(|f| f.starts_with("exec_from_"));
+        let has_lolbin = flags.contains(&"lolbin_process".to_string());
+        let has_masquerade = flags.contains(&"lolbin_masquerade".to_string());
+        let has_renamed = flags.contains(&"renamed_binary".to_string());
+
+        let severity = if has_masquerade {
+            // Renamed LOLBin — always High regardless of path
             Severity::High
-        } else if flags.iter().any(|f| f.starts_with("exec_from_")) || flags.contains(&"lolbin_process".to_string()) {
+        } else if has_exec_from && has_lolbin {
+            // LOLBin running from a suspicious path
+            Severity::High
+        } else if has_renamed && has_lolbin {
+            // LOLBin copied but running from a non-suspicious path
+            Severity::High
+        } else if has_exec_from || has_lolbin {
+            Severity::Medium
+        } else if has_renamed {
+            // Non-LOLBin renamed binary — worth investigating
             Severity::Medium
         } else if flags.is_empty() {
             Severity::Low
@@ -89,49 +213,5 @@ impl RuleEngine {
         };
 
         DetectionResult { flags, severity }
-    }
-
-        pub fn quick_flags(&self, proc_name: &str, exe_path: Option<&str>) -> Vec<String> {
-        let mut flags: Vec<String> = Vec::new();
-
-        let name_lc = proc_name.to_lowercase();
-        let path_lc = exe_path.unwrap_or("").to_lowercase();
-
-        if !path_lc.is_empty() {
-            if path_lc.contains("\\appdata\\local\\temp\\") || path_lc.contains("\\windows\\temp\\") {
-                flags.push("exec_from_temp".to_string());
-            }
-            if path_lc.contains("\\downloads\\") {
-                flags.push("exec_from_downloads".to_string());
-            }
-            if path_lc.contains("\\appdata\\roaming\\") || path_lc.contains("\\appdata\\local\\") {
-                flags.push("exec_from_appdata".to_string());
-            }
-        } else {
-            flags.push("no_exe_path".to_string());
-        }
-
-        let lolbins = [
-            "powershell.exe",
-            "pwsh.exe",
-            "cmd.exe",
-            "wscript.exe",
-            "cscript.exe",
-            "mshta.exe",
-            "rundll32.exe",
-            "regsvr32.exe",
-            "certutil.exe",
-            "bitsadmin.exe",
-            "wmic.exe",
-        ];
-        if lolbins.iter().any(|x| *x == name_lc) {
-            flags.push("lolbin_process".to_string());
-        }
-
-        if self.allowlisted_names.contains(&name_lc) {
-            flags.push("allowlisted_name".to_string());
-        }
-
-        flags
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,14 +52,17 @@ fn run_once(engine: &RuleEngine, out_path: &str) -> Result<()> {
 
     for p in snapshot {
     let exe_str = p.exe_path.as_ref().map(|x| x.to_string_lossy().to_string());
+    let orig_fn = p.original_filename.as_deref();
 
-    let quick = engine.quick_flags(&p.name, exe_str.as_deref());
+    let quick = engine.quick_flags(&p.name, exe_str.as_deref(), orig_fn);
 
     let should_hash = quick.iter().any(|f|
         f == "exec_from_temp" ||
         f == "exec_from_downloads" ||
         f == "exec_from_appdata" ||
-        f == "lolbin_process"
+        f == "lolbin_process" ||
+        f == "renamed_binary" ||
+        f == "lolbin_masquerade"
     );
 
     let sha_str = if should_hash {
@@ -74,6 +77,7 @@ fn run_once(engine: &RuleEngine, out_path: &str) -> Result<()> {
     let det = engine.detect(
         &p.name,
         exe_str.as_deref(),
+        orig_fn,
         sha_str.as_deref(),
     );
 
@@ -82,6 +86,7 @@ fn run_once(engine: &RuleEngine, out_path: &str) -> Result<()> {
         pid: p.pid,
         name: p.name,
         exe_path: exe_str,
+        original_filename: p.original_filename,
         sha256: sha_str,
         flags: det.flags,
         severity: det.severity,

--- a/src/models.rs
+++ b/src/models.rs
@@ -14,6 +14,7 @@ pub struct ProcEvent {
     pub pid: u32,
     pub name: String,
     pub exe_path: Option<String>,
+    pub original_filename: Option<String>,
     pub sha256: Option<String>,
     pub flags: Vec<String>,
     pub severity: Severity,


### PR DESCRIPTION
Dear Steven Jonathan,

When I analyzed the code last night, I notice the current rules.rs detects LOLBins only by process name. If an attacker copies powershell.exe to C:\Temp\updater.exe, the name check fails and it gets classified as Low severity. I consider a solution that you can review ASAP, I suggest to implement original filename detection using Windows PE VersionInfo metadata. Every Windows PE binary has an embedded OriginalFilename field in its resource section that cannot be changer by simply renaming the file, because it requires recompiling the binary, so in this approaches, we can do another techniques such as:

PE Versionifno Parsing, Read the OriginalFilename from the executable's version resource.
Apply a fallback approach when we counter a Mismatch Detection if OriginalFilename != actual filename, flag it as renamed_binary.
LOLBin detection by original name when we check the OriginalFilename against the LOLBin list, not just the current process name.
Sincerely,
Ivan :)